### PR TITLE
Add default search values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
-
+  - 2.6.1
 bundler_args: --without docs
-
-notifications:
-  email:
-    - brwcodes@gmail.com

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ KeywordSearch.search(terms) do |with|
     arguments << "%#{values.join(' ')}%"
   end
 
+  # A keyword description can be passed as the second argument of the
+  # `keyword` call, and read back as an attribute on the keyword
+  with.keyword :title, 'Some description of the title search here' do |values|
+    ...
+  end
+
+  # Default values can be passed as the `keyword` call's third argument.
+  # Such default values will be assumed to be part of the search string
+  # if its keyword is not already present in that string.  Defaults are
+  # always positive.
+  with.keyword :title, nil, "Dr." do |values|
+    # A search on 'title:Mr.' will yield a `values` of `['Mr.']`
+    # A search on 'has:something' will yield a `values` of `['Dr.']`
+  end
+
 end
 ```
 

--- a/keyword_search.gemspec
+++ b/keyword_search.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.rdoc_options  = ["--charset=UTF-8"]
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
 end

--- a/lib/keyword_search.rb
+++ b/lib/keyword_search.rb
@@ -15,6 +15,7 @@ module KeywordSearch
     def search(input_string, definition=nil, &block)
       definition ||= Definition.new(&block)
       results = parse(input_string)
+      add_default_values(results, definition)
       results.each do |key, terms|
         definition.handle(key, terms)
       end
@@ -24,6 +25,13 @@ module KeywordSearch
     #######
     private
     #######
+    
+    def add_default_values(results, definition)
+      definition.keywords.each do |keyword|
+      	next if keyword.default_values.nil?
+      	results[keyword.name.to_s] ||= parse(keyword.default_values)[:default]
+      end
+    end
     
     def parse(input) #:nodoc:
       data = input + ' '
@@ -2285,5 +2293,4 @@ end
   end
   
 end
-
 

--- a/lib/keyword_search/definition.rb
+++ b/lib/keyword_search/definition.rb
@@ -4,9 +4,9 @@ module KeywordSearch
 
     class Keyword
 
-      attr_reader :name, :description, :handler
-      def initialize(name, description=nil, &handler)
-        @name, @description = name, description
+      attr_reader :name, :description, :default_values, :handler
+      def initialize(name, description=nil, default_values=nil, &handler)
+        @name, @description, @default_values = name, description, default_values
         @handler = handler
       end
 
@@ -31,8 +31,8 @@ module KeywordSearch
       @keywords ||= []
     end
 
-    def keyword(name, description=nil, &block)
-      keywords << Keyword.new(name, description, &block)
+    def keyword(name, description=nil, default_values=nil, &block)
+      keywords << Keyword.new(name, description, default_values, &block)
     end
 
     def default_keyword(name)

--- a/lib/keyword_search/version.rb
+++ b/lib/keyword_search/version.rb
@@ -1,3 +1,3 @@
 module KeywordSearch
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end

--- a/test/test_keyword_search.rb
+++ b/test/test_keyword_search.rb
@@ -333,4 +333,28 @@ describe "KeywordSearch" do
     end
     assert_equal [ [ %w(google.com), false ] ], result
   end
+
+  it 'a search falling back to default values' do
+    result = []
+
+    KeywordSearch.search(%<>) do |with|
+      with.keyword :some_flag, nil, "false" do |values, positive|
+        result << [ values, positive ]
+      end
+    end
+
+    assert_equal [ [ %w(false), true ] ], result
+  end
+
+  it 'a search should not use default values when explicit values present' do
+    result = []
+
+    KeywordSearch.search(%<some_flag:true>) do |with|
+      with.keyword :some_flag, nil, "false" do |values, positive|
+        result << [ values, positive ]
+      end
+    end
+
+    assert_equal [ [ %w(true), true ] ], result
+  end
 end


### PR DESCRIPTION
Lets keywords be defined with default values that will be used if the keyword is not included in the incoming search string.  We have a use case where we always want a search to include a default search term of "some_flag:false" if "some_flag" is not otherwise specified.  The README changes have more specifics.  